### PR TITLE
Preserve SSH key comment if it exists

### DIFF
--- a/lib/puppet/parser/functions/users_hash_sshkeys.rb
+++ b/lib/puppet/parser/functions/users_hash_sshkeys.rb
@@ -6,7 +6,11 @@ module Puppet::Parser::Functions
     keys = [ args[1] ].flatten
     keys.each do |key|
       parts = key.split
-      comment = "#{user}_#{count}"
+      if parts.count == 3 then
+        comment = "#{parts[2]}_#{user}_#{count}"
+      else
+        comment = "#{user}_#{count}"
+      end
       sshkeyhash[comment] = Hash.new
       sshkeyhash[comment]['type'] = parts[0]
       sshkeyhash[comment]['key'] = parts[1]


### PR DESCRIPTION
In a more perfect world, one would never have the same private key on more than one system. If that person logs into servers from more than one workstation it is helpful to know which key is which at a glance without digging into hiera data (which won't exist on the target server, anyway).